### PR TITLE
Updated CommonLibSSE-NG, made changes to support 1.6.629+

### DIFF
--- a/src/Loot.h
+++ b/src/Loot.h
@@ -84,7 +84,9 @@ private:
 		auto player = RE::PlayerCharacter::GetSingleton();
 		if (!player ||
 			player->IsGrabbing() ||
-			player->HasActorDoingCommand() ||
+		  // NOTE: the following two conditions *should* be equivalent, but they aren't due to an apparent bug in Clib-NG.
+			//player->HasActorDoingCommand() ||
+			static_cast<bool>(player->GetActorDoingPlayerCommand()) ||
 			(Settings::CloseInCombat() && player->IsInCombat())) {
 			return false;
 		}

--- a/src/Scaleform/LootMenu.h
+++ b/src/Scaleform/LootMenu.h
@@ -134,7 +134,7 @@ namespace Scaleform
 				_openCloseHandler.Open();
 
 				if (Settings::DispelInvisibility()) {
-					dst->DispelEffectsWithArchetype(RE::EffectArchetypes::ArchetypeID::kInvisibility, false);
+					dst->AsMagicTarget()->DispelEffectsWithArchetype(RE::EffectArchetypes::ArchetypeID::kInvisibility, false);
 				}
 			}
 
@@ -449,7 +449,7 @@ namespace Scaleform
 				auto inventoryWeight =
 					static_cast<std::ptrdiff_t>(dst->GetWeightInContainer());
 				auto carryWeight =
-					static_cast<std::ptrdiff_t>(dst->GetActorValue(RE::ActorValue::kCarryWeight));
+					static_cast<std::ptrdiff_t>(dst->AsActorValueOwner()->GetActorValue(RE::ActorValue::kCarryWeight));
 				auto text = std::to_string(inventoryWeight);
 				text += " / ";
 				text += std::to_string(carryWeight);

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -4,7 +4,7 @@
     {
       "kind": "git",
       "repository": "https://gitlab.com/colorglass/vcpkg-colorglass",
-      "baseline": "5dffebb79a2c9cdc48bca6bcee3dfcf78eeeb300",
+      "baseline": "1b279b20c7e0db1c9d549ff3b64e024c01317b55",
       "packages": [
         "articuno",
         "skse",


### PR DESCRIPTION
There seems to be a bug in CommonLibSSE-NG which made this slightly less straightforward than it should have been. See https://github.com/CharmedBaryon/CommonLibSSE-NG/issues/57. Regardless, the workaround is not bad and the changes were otherwise easy.

Tested on 1.5.97, 1.6.353, and 1.6.640.